### PR TITLE
feat: add REST API view set for the catalogue app models.

### DIFF
--- a/catalog_plugin/api/__init__.py
+++ b/catalog_plugin/api/__init__.py
@@ -1,0 +1,1 @@
+"""Init file for api module."""

--- a/catalog_plugin/api/urls.py
+++ b/catalog_plugin/api/urls.py
@@ -1,0 +1,7 @@
+"""Urls API file."""
+from django.conf.urls import include, url
+
+app_name = 'catalog_plugin.api'
+urlpatterns = [
+    url(r'^v0/', include('catalog_plugin.api.v0.urls', namespace='v0')),
+]

--- a/catalog_plugin/api/v0/__init__.py
+++ b/catalog_plugin/api/v0/__init__.py
@@ -1,0 +1,1 @@
+"""Init file for api v0 module."""

--- a/catalog_plugin/api/v0/filters.py
+++ b/catalog_plugin/api/v0/filters.py
@@ -1,0 +1,48 @@
+"""Filters for the api.v0 module."""
+import django_filters
+from catalog_plugin.models import AvailableCourse, FixedCatalog, CatalogCourses
+
+
+class AvailableCourseFilter(django_filters.FilterSet):
+    """
+    FilterSet for AvailableCourse model.
+    Allows filtering by course ID and active status.
+    """
+    course_id = django_filters.CharFilter(field_name='course__id')
+    active = django_filters.BooleanFilter(field_name='active')
+
+    class Meta:
+        """Meta class."""
+        model = AvailableCourse
+        fields = ['course_id', 'active']
+
+
+class FixedCatalogFilter(django_filters.FilterSet):
+    """
+    FilterSet for FixedCatalog model.
+    Allows filtering by name, active status, and creation date ranges.
+    """
+    name = django_filters.CharFilter(field_name='name', lookup_expr='icontains')
+    active = django_filters.BooleanFilter(field_name='active')
+    created_after = django_filters.DateFilter(field_name='created', lookup_expr='gte')
+    created_before = django_filters.DateFilter(field_name='created', lookup_expr='lte')
+
+    class Meta:
+        """Meta class."""
+        model = FixedCatalog
+        fields = ['name', 'active', 'created_after', 'created_before']
+
+
+class CatalogCoursesFilter(django_filters.FilterSet):
+    """
+    FilterSet for CatalogCourses model.
+    Allows filtering by name, active status, and related courses.
+    """
+    name = django_filters.CharFilter(field_name='name', lookup_expr='icontains')
+    active = django_filters.BooleanFilter(field_name='active')
+    course_id = django_filters.CharFilter(field_name='courses__id')
+
+    class Meta:
+        """Meta class."""
+        model = CatalogCourses
+        fields = ['name', 'active', 'course_id']

--- a/catalog_plugin/api/v0/serializers.py
+++ b/catalog_plugin/api/v0/serializers.py
@@ -1,0 +1,64 @@
+"""Serializers module for API v0."""
+# your_app_name/serializers.py
+from rest_framework import serializers
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from catalog_plugin.models import AvailableCourse, FixedCatalog, CatalogCourses
+
+
+class CourseKeySerializer(serializers.BaseSerializer):  # pylint: disable=abstract-method
+    """Class that contains the course key serializer."""
+
+    def to_representation(self, data):
+        """Set the representation value of the instance."""
+        return str(data)
+
+    def to_internal_value(self, data):
+        """Validate the input value."""
+        try:
+            return CourseKey.from_string(data)
+        except InvalidKeyError:
+            raise serializers.ValidationError(  # pylint: disable=raise-missing-from
+                'Invalid course key: {}.'.format(data),
+            )
+
+
+class AvailableCourseSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the AvailableCourse model.
+    """
+    course = CourseKeySerializer()
+
+    class Meta:
+        model = AvailableCourse
+        fields = ['id', 'course', 'active']
+
+
+class FixedCatalogSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the FixedCatalog model.
+    """
+    course_runs = serializers.PrimaryKeyRelatedField(
+        many=True,
+        queryset=AvailableCourse.objects.none(),
+        required=False,
+    )
+
+    class Meta:
+        model = FixedCatalog
+        fields = ['id', 'slug', 'name', 'course_runs']
+
+
+class CatalogCoursesSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the CatalogCourses model.
+    """
+    courses = serializers.PrimaryKeyRelatedField(
+        many=True,
+        queryset=AvailableCourse.objects.all(),
+    )
+
+    class Meta:
+        model = CatalogCourses
+        fields = ['id', 'slug', 'name', 'courses']

--- a/catalog_plugin/api/v0/urls.py
+++ b/catalog_plugin/api/v0/urls.py
@@ -1,0 +1,16 @@
+"""URL for the API v0."""
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+
+from catalog_plugin.api.v0 import views
+
+app_name = 'catalog_plugin.api.v0'
+router = DefaultRouter()
+
+router.register(r'available-courses', views.AvailableCourseViewSet, basename='availablecourse')
+router.register(r'fixed-catalogs', views.FixedCatalogViewSet, basename='fixedcatalog')
+router.register(r'catalog-courses', views.CatalogCoursesViewSet, basename='catalogcourses')
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/catalog_plugin/api/v0/views.py
+++ b/catalog_plugin/api/v0/views.py
@@ -1,0 +1,68 @@
+"""Views module for API v0."""
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.permissions import IsAuthenticated, IsStaff
+from rest_framework import viewsets, filters
+from django_filters.rest_framework import DjangoFilterBackend
+
+from catalog_plugin.models import AvailableCourse, FixedCatalog, CatalogCourses
+from catalog_plugin.api.v0.serializers import (
+    AvailableCourseSerializer,
+    FixedCatalogSerializer,
+    CatalogCoursesSerializer,
+)
+from catalog_plugin.api.v0.filters import (
+    AvailableCourseFilter,
+    FixedCatalogFilter,
+    CatalogCoursesFilter,
+)
+
+
+class AvailableCourseViewSet(viewsets.ModelViewSet):
+    """
+    A viewset for viewing and editing AvailableCourse instances.
+    """
+
+    authentication_classes = (JwtAuthentication,)
+    permission_classes = (IsAuthenticated, IsStaff)
+    queryset = AvailableCourse.objects.all()
+    serializer_class = AvailableCourseSerializer
+
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_class = AvailableCourseFilter
+    search_fields = ['course__name']
+    ordering_fields = ['course', 'active', 'id']
+    ordering = ['id']
+
+
+class FixedCatalogViewSet(viewsets.ModelViewSet):
+    """
+    A viewset for viewing and editing FixedCatalog instances.
+    """
+
+    authentication_classes = (JwtAuthentication,)
+    permission_classes = (IsAuthenticated, IsStaff)
+    queryset = FixedCatalog.objects.all()
+    serializer_class = FixedCatalogSerializer
+
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_class = FixedCatalogFilter
+    search_fields = ['name']
+    ordering_fields = ['name', 'created', 'modified', 'id']
+    ordering = ['created']
+
+
+class CatalogCoursesViewSet(viewsets.ModelViewSet):
+    """
+    A viewset for viewing and editing CatalogCourses instances.
+    """
+
+    authentication_classes = (JwtAuthentication,)
+    permission_classes = (IsAuthenticated, IsStaff)
+    queryset = CatalogCourses.objects.all()
+    serializer_class = CatalogCoursesSerializer
+
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_class = CatalogCoursesFilter
+    search_fields = ['name', 'courses__course__name']
+    ordering_fields = ['name', 'created', 'modified', 'id']
+    ordering = ['name']

--- a/catalog_plugin/settings/common.py
+++ b/catalog_plugin/settings/common.py
@@ -3,6 +3,21 @@
 from typing import Any
 
 
+INSTALLED_APPS = [
+    'rest_framework',
+    'django_filters',
+    'catalog_plugin',
+]
+
+REST_FRAMEWORK = {
+    'DEFAULT_FILTER_BACKENDS': [
+        'django_filters.rest_framework.DjangoFilterBackend',
+        'rest_framework.filters.SearchFilter',
+        'rest_framework.filters.OrderingFilter',
+    ],
+}
+
+
 def plugin_settings(settings: Any):  # pylint: disable=unused-argument
     """Open edX plugin settings.
 

--- a/catalog_plugin/urls.py
+++ b/catalog_plugin/urls.py
@@ -4,5 +4,10 @@ Attributes:
     app_name (str): URL pattern namespace.
     urlpatterns (list): URL patterns list.
 """
+from django.conf.urls import include, url
 
-urlpatterns = []  # type: ignore
+app_name = 'catalog_plugin'
+
+urlpatterns = [
+    url(r'^api/', include('catalog_plugin.api.urls', namespace='api')),
+]

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,6 +11,7 @@
 # Use Django LTS.
 django<5.0
 django-model-utils==4.2.0
+django-filter==22.1
 
 # Set pip-tools.in constraints.
 pip-tools<=7.4.1


### PR DESCRIPTION
## Description

This PR adds the REST APIs for the models related to flexible catalogs.

## Changes made

- [x] Add api v0
- [x] Add serializers and views

## How to test

**For AvailableCourseViewSet (`/api/available-courses/`):**  
- **GET** (list): `GET /api/available-courses/`  
- **POST** (create): `POST /api/available-courses/`  
- **GET** (retrieve): `GET /api/available-courses/<pk>/`  
- **PUT** (update): `PUT /api/available-courses/<pk>/`  
- **PATCH** (partial update): `PATCH /api/available-courses/<pk>/`  
- **DELETE** (destroy): `DELETE /api/available-courses/<pk>/`

**For FixedCatalogViewSet (`/api/fixed-catalogs/`):**  
- **GET** (list): `GET /api/fixed-catalogs/`  
- **POST** (create): `POST /api/fixed-catalogs/`  
- **GET** (retrieve): `GET /api/fixed-catalogs/<pk>/`  
- **PUT** (update): `PUT /api/fixed-catalogs/<pk>/`  
- **PATCH** (partial update): `PATCH /api/fixed-catalogs/<pk>/`  
- **DELETE** (destroy): `DELETE /api/fixed-catalogs/<pk>/`

**For CatalogCoursesViewSet (`/api/catalog-courses/`):**  
- **GET** (list): `GET /api/catalog-courses/`  
- **POST** (create): `POST /api/catalog-courses/`  
- **GET** (retrieve): `GET /api/catalog-courses/<pk>/`  
- **PUT** (update): `PUT /api/catalog-courses/<pk>/`  
- **PATCH** (partial update): `PATCH /api/catalog-courses/<pk>/`  
- **DELETE** (destroy): `DELETE /api/catalog-courses/<pk>/`

## Reviewers

- [x] @Squirrel18 