### PR TITLE
feat: add REST API for FlexibleCatalogModel.

### DIFF
--- a/catalog_plugin/api/v0/filters.py
+++ b/catalog_plugin/api/v0/filters.py
@@ -1,6 +1,11 @@
 """Filters for the api.v0 module."""
 import django_filters
-from catalog_plugin.models import AvailableCourse, FixedCatalog, CatalogCourses
+from catalog_plugin.models import (
+    FlexibleCatalogModel,
+    AvailableCourse,
+    FixedCatalog,
+    CatalogCourses,
+)
 
 
 class AvailableCourseFilter(django_filters.FilterSet):
@@ -15,6 +20,19 @@ class AvailableCourseFilter(django_filters.FilterSet):
         """Meta class."""
         model = AvailableCourse
         fields = ['course_id', 'active']
+
+
+class FlexibleCatalogFilter(django_filters.FilterSet):
+    """
+    FilterSet for FlexibleCatalogModel.
+    Allows filtering by name and slug.
+    """
+    name = django_filters.CharFilter(field_name='name', lookup_expr='icontains')
+    slug = django_filters.CharFilter(field_name='slug', lookup_expr='icontains')
+
+    class Meta:
+        model = FlexibleCatalogModel
+        fields = ['name', 'slug']
 
 
 class FixedCatalogFilter(django_filters.FilterSet):

--- a/catalog_plugin/api/v0/serializers.py
+++ b/catalog_plugin/api/v0/serializers.py
@@ -4,7 +4,12 @@ from rest_framework import serializers
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from catalog_plugin.models import AvailableCourse, FixedCatalog, CatalogCourses
+from catalog_plugin.models import (
+    FlexibleCatalogModel,
+    AvailableCourse,
+    FixedCatalog,
+    CatalogCourses,
+)
 
 
 class CourseKeySerializer(serializers.BaseSerializer):  # pylint: disable=abstract-method
@@ -33,6 +38,15 @@ class AvailableCourseSerializer(serializers.ModelSerializer):
     class Meta:
         model = AvailableCourse
         fields = ['id', 'course', 'active']
+
+
+class FlexibleCatalogSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the FlexibleCatalog model.
+    """
+    class Meta:
+        model = FlexibleCatalogModel
+        fields = ['id', 'slug', 'name']
 
 
 class FixedCatalogSerializer(serializers.ModelSerializer):

--- a/catalog_plugin/api/v0/urls.py
+++ b/catalog_plugin/api/v0/urls.py
@@ -7,6 +7,7 @@ from catalog_plugin.api.v0 import views
 app_name = 'catalog_plugin.api.v0'
 router = DefaultRouter()
 
+router.register(r'flexible-catalogs', views.FlexibleCatalogViewSet, basename='flexible-catalog')
 router.register(r'available-courses', views.AvailableCourseViewSet, basename='availablecourse')
 router.register(r'fixed-catalogs', views.FixedCatalogViewSet, basename='fixedcatalog')
 router.register(r'catalog-courses', views.CatalogCoursesViewSet, basename='catalogcourses')

--- a/catalog_plugin/api/v0/views.py
+++ b/catalog_plugin/api/v0/views.py
@@ -4,13 +4,20 @@ from edx_rest_framework_extensions.permissions import IsAuthenticated, IsStaff
 from rest_framework import viewsets, filters
 from django_filters.rest_framework import DjangoFilterBackend
 
-from catalog_plugin.models import AvailableCourse, FixedCatalog, CatalogCourses
+from catalog_plugin.models import (
+    FlexibleCatalogModel,
+    AvailableCourse,
+    FixedCatalog,
+    CatalogCourses,
+)
 from catalog_plugin.api.v0.serializers import (
+    FlexibleCatalogSerializer,
     AvailableCourseSerializer,
     FixedCatalogSerializer,
     CatalogCoursesSerializer,
 )
 from catalog_plugin.api.v0.filters import (
+    FlexibleCatalogFilter,
     AvailableCourseFilter,
     FixedCatalogFilter,
     CatalogCoursesFilter,
@@ -32,6 +39,23 @@ class AvailableCourseViewSet(viewsets.ModelViewSet):
     search_fields = ['course__name']
     ordering_fields = ['course', 'active', 'id']
     ordering = ['id']
+
+
+class FlexibleCatalogViewSet(viewsets.ModelViewSet):
+    """
+    A viewset for viewing and editing FlexibleCatalogModel instances.
+    """
+
+    authentication_classes = (JwtAuthentication,)
+    permission_classes = (IsAuthenticated, IsStaff)
+    queryset = FlexibleCatalogModel.objects.all()
+    serializer_class = FlexibleCatalogSerializer
+
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_class = FlexibleCatalogFilter
+    search_fields = ['name', 'slug']
+    ordering_fields = ['name', 'slug', 'id']
+    ordering = ['name']
 
 
 class FixedCatalogViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Description

This PR adds the REST API for FlexibleCatalogModel.

## Changes made

- [x] Add REST API for FlexibleCatalogModel

## How to test

GET:
-  http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/
-  http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/<uuid>/

POST :
-  http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/
body = { "name": "New Catalog", "slug": "new-catalog" }

PUT:
-  http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/
body = { "name": "Update Catalog", "slug": "update-catalog" }

PATCH:
-  http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/
body = { "name": "Partial update" }

DELETE:
- http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/<uuid>/

Filters:

- http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/?name=catalog
- http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/??slug=new
- http://localhost:18000/catalog_plugin/api/v0//flexible-catalogs/?search=catalog

Ordering:

- http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/?ordering=name
- http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/?ordering=-name
- http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/?ordering=id
- http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/?ordering=-id

Example with filters and ordering:

- http://localhost:18000/catalog_plugin/api/v0/flexible-catalogs/?name=catalog&search=new&ordering=name

## Reviewers

- [x] @Squirrel18 