### PR TITLE
build: add missed dependencies

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,3 +2,8 @@
 -c constraints.txt
 
 Django
+django-model-utils
+djangorestframework
+edx-opaque-keys
+edx-drf-extensions
+django-filter

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,18 +4,156 @@
 #
 #    pip-compile --output-file=requirements/base.txt requirements/base.in
 #
-
-asgiref==3.8.1
-    # via django
-backports-zoneinfo==0.2.1 ; python_version < "3.9"
+asgiref==3.5.2
     # via
     #   -c requirements/constraints.txt
     #   django
-django==4.2.16
+certifi==2022.9.24
+    # via
+    #   -c requirements/constraints.txt
+    #   requests
+cffi==1.15.1
+    # via
+    #   -c requirements/constraints.txt
+    #   cryptography
+    #   pynacl
+charset-normalizer==2.0.12
+    # via
+    #   -c requirements/constraints.txt
+    #   requests
+click==8.1.3
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-django-utils
+cryptography==36.0.2
+    # via
+    #   -c requirements/constraints.txt
+    #   pyjwt
+django==3.2.17
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-sqlparse==0.5.2
-    # via django
-typing-extensions==4.12.2
-    # via asgiref
+    #   django-crum
+    #   django-filter
+    #   django-model-utils
+    #   djangorestframework
+    #   drf-jwt
+    #   edx-django-utils
+    #   edx-drf-extensions
+django-crum==0.7.9
+    # via edx-django-utils
+django-filter==22.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+django-model-utils==4.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+django-waffle==3.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-django-utils
+    #   edx-drf-extensions
+djangorestframework==3.12.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+    #   drf-jwt
+    #   edx-drf-extensions
+drf-jwt==1.19.2
+    # via edx-drf-extensions
+edx-django-utils==5.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-drf-extensions
+edx-drf-extensions==8.3.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+edx-opaque-keys==2.3.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+    #   edx-drf-extensions
+future==0.18.2
+    # via
+    #   -c requirements/constraints.txt
+    #   pyjwkest
+idna==3.4
+    # via
+    #   -c requirements/constraints.txt
+    #   requests
+newrelic==8.2.1
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-django-utils
+pbr==5.10.0
+    # via
+    #   -c requirements/constraints.txt
+    #   stevedore
+psutil==5.9.2
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-django-utils
+pycparser==2.21
+    # via
+    #   -c requirements/constraints.txt
+    #   cffi
+pycryptodomex==3.15.0
+    # via
+    #   -c requirements/constraints.txt
+    #   pyjwkest
+pyjwkest==1.4.2
+    # via edx-drf-extensions
+pyjwt[crypto]==2.5.0
+    # via
+    #   -c requirements/constraints.txt
+    #   drf-jwt
+    #   edx-drf-extensions
+pymongo==3.12.3
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-opaque-keys
+pynacl==1.5.0
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-django-utils
+python-dateutil==2.8.2
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-drf-extensions
+pytz==2022.2.1
+    # via
+    #   -c requirements/constraints.txt
+    #   django
+requests==2.28.1
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-drf-extensions
+    #   pyjwkest
+semantic-version==2.10.0
+    # via edx-drf-extensions
+six==1.16.0
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-drf-extensions
+    #   pyjwkest
+    #   python-dateutil
+sqlparse==0.4.3
+    # via
+    #   -c requirements/constraints.txt
+    #   django
+stevedore==4.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-django-utils
+    #   edx-opaque-keys
+types-cryptography==3.3.23
+    # via
+    #   -c requirements/constraints.txt
+    #   pyjwt
+urllib3==1.26.12
+    # via
+    #   -c requirements/constraints.txt
+    #   requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,9 +9,16 @@
 # linking to it here is good.
 
 # Use Django LTS.
-django<5.0
+django==3.2.17
 django-model-utils==4.2.0
 django-filter==22.1
+djangorestframework==3.12.4
+edx-django-utils==5.2.0
+
+#edx
+edx-opaque-keys==2.3.0
+edx-drf-extensions==8.3.1
+
 
 # Set pip-tools.in constraints.
 pip-tools<=7.4.1
@@ -22,3 +29,74 @@ backports.zoneinfo;python_version<'3.9'
 
 # Avoid astroid>3.2.4 when using python<'3.9'.
 astroid<=3.2.4;python_version<'3.9'
+
+#via edx-platform base.txt
+asgiref==3.5.2
+certifi==2022.9.24
+cffi==1.15.1
+charset-normalizer==2.0.12
+click==8.1.3
+cryptography==36.0.2
+django-waffle==3.0.0
+future==0.18.2
+idna==3.4
+newrelic==8.2.1
+pbr==5.10.0
+psutil==5.9.2
+pycparser==2.21
+pycryptodomex==3.15.0
+pyjwt==2.5.0
+pymongo==3.12.3
+pynacl==1.5.0
+python-dateutil==2.8.2
+pytz==2022.2.1
+requests==2.28.1
+six==1.16.0
+sqlparse==0.4.3
+stevedore==4.0.0
+urllib3==1.26.12
+
+
+# via edx-platform development.txt
+anyio==3.6.1
+astroid==2.11.7
+attrs==22.1.0
+chardet==5.0.0
+coverage==6.5.0
+dill==0.3.5.1
+distlib==0.3.6
+filelock==3.8.0
+importlib-resources==5.10.0
+iniconfig==1.1.1
+isort==5.10.1
+jsonschema==4.16.0
+mypy==0.982
+mypy-extensions==0.4.3
+nodeenv==1.7.0
+packaging==21.3
+platformdirs==2.5.2
+pluggy==1.0.0
+prompt-toolkit==3.0.31
+pycodestyle==2.8.0
+pydantic==1.10.2
+pygments==2.13.0
+pylint==2.13.9
+pylint-django==2.5.3
+pylint-plugin-utils==0.7
+pytest==7.1.3
+pytest-django==4.5.2
+pyyaml==6.0
+sniffio==1.3.0
+tomli==2.0.1
+tox==3.26.0
+types-cryptography==3.3.23
+typing-extensions==4.4.0
+virtualenv==20.16.5
+wrapt==1.14.1
+yarl==1.8.1
+zipp==3.9.0
+
+# via edx-platform pip-tools.txt
+build==0.8.0
+pip-tools==6.9.0
+wheel==0.37.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,132 +4,223 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
-
-annotated-types==0.7.0
-    # via pydantic
-asgiref==3.8.1
+asgiref==3.5.2
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-    #   django-stubs
-astroid==3.2.4 ; python_version < "3.9"
+astroid==2.11.7 ; python_version < "3.9"
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-attrs==24.2.0
+attrs==22.1.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   jsonschema
+    #   pytest
     #   referencing
-backports-zoneinfo==0.2.1 ; python_version < "3.9"
+bump-my-version==0.10.0
+    # via -r requirements/dev.in
+certifi==2022.9.24
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   django
-bracex==2.5.post1
-    # via wcmatch
-bump-my-version==0.28.1
-    # via -r requirements/dev.in
-cachetools==5.5.0
+    #   requests
+cffi==1.15.1
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   tox
+    #   cryptography
+    #   pynacl
 cfgv==3.4.0
     # via
     #   -r requirements/quality.txt
     #   pre-commit
-chardet==5.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   tox
-click==8.1.7
-    # via
-    #   bump-my-version
-    #   rich-click
-colorama==0.4.6
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   tox
-coverage==7.6.1
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-dill==0.3.9
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   pylint
-distlib==0.3.9
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   virtualenv
-django==4.2.16
+charset-normalizer==2.0.12
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   django-stubs
-    #   django-stubs-ext
-django-stubs[compatible-mypy]==5.1.1
+    #   requests
+click==8.1.3
     # via
-    #   -r requirements/quality.txt
-    #   django-stubs
-django-stubs-ext==5.1.1
-    # via
-    #   -r requirements/quality.txt
-    #   django-stubs
-exceptiongroup==1.2.2
-    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   pytest
-filelock==3.16.1
+    #   bump-my-version
+    #   edx-django-utils
+    #   rich-click
+coverage==6.5.0
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+cryptography==36.0.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pyjwt
+dill==0.3.5.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pylint
+distlib==0.3.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   virtualenv
+django==3.2.17
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   django-crum
+    #   django-filter
+    #   django-model-utils
+    #   django-stubs
+    #   django-stubs-ext
+    #   djangorestframework
+    #   drf-jwt
+    #   edx-django-utils
+    #   edx-drf-extensions
+django-crum==0.7.9
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+django-filter==22.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+django-model-utils==4.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+django-stubs[compatible-mypy]==1.13.2
+    # via -r requirements/quality.txt
+django-stubs-ext==5.1.3
+    # via
+    #   -r requirements/quality.txt
+    #   django-stubs
+django-waffle==3.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+    #   edx-drf-extensions
+djangorestframework==3.12.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   drf-jwt
+    #   edx-drf-extensions
+drf-jwt==1.19.2
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+edx-django-utils==5.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+edx-drf-extensions==8.3.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+edx-opaque-keys==2.3.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+filelock==3.8.0
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
+future==0.18.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pyjwkest
 identify==2.6.1
     # via
     #   -r requirements/quality.txt
     #   pre-commit
-importlib-resources==6.4.5
+idna==3.4
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   requests
+    #   yarl
+importlib-resources==5.10.0
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   jsonschema
-    #   jsonschema-specifications
-iniconfig==2.0.0
+iniconfig==1.1.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest
-isort==5.13.2
+isort==5.10.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-jsonschema==4.23.0
+jsonschema==4.16.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+lazy-object-proxy==1.10.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-jsonschema-specifications==2023.12.1
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   jsonschema
+    #   astroid
 markdown-it-py==3.0.0
     # via rich
 mccabe==0.7.0
@@ -139,187 +230,331 @@ mccabe==0.7.0
     #   pylint
 mdurl==0.1.2
     # via markdown-it-py
-mypy==1.13.0
+multidict==6.1.0
     # via
+    #   -r requirements/quality.txt
+    #   yarl
+mypy==0.982
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   django-stubs
-mypy-extensions==1.0.0
+mypy-extensions==0.4.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   mypy
-nodeenv==1.9.1
+newrelic==8.2.1
     # via
-    #   -r requirements/quality.txt
-    #   pre-commit
-packaging==24.2
-    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   pyproject-api
+    #   edx-django-utils
+nodeenv==1.7.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   pre-commit
+packaging==21.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pytest
     #   tox
+pbr==5.10.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   stevedore
 pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==4.3.6
+platformdirs==2.5.2
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-    #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.0.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest
     #   tox
 pre-commit==3.5.0
     # via -r requirements/quality.txt
-prompt-toolkit==3.0.36
-    # via questionary
-pycodestyle==2.12.1
+psutil==5.9.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+py==1.11.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-pydantic==2.10.1
+    #   pytest
+    #   tox
+pycodestyle==2.8.0
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+pycparser==2.21
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   cffi
+pycryptodomex==3.15.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pyjwkest
+pydantic==1.10.2
+    # via
+    #   -c requirements/constraints.txt
     #   bump-my-version
-    #   pydantic-settings
-pydantic-core==2.27.1
-    # via pydantic
-pydantic-settings==2.6.1
-    # via bump-my-version
 pydocstyle==6.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-pygments==2.18.0
-    # via rich
-pylint==3.2.7
+pygments==2.13.0
     # via
+    #   -c requirements/constraints.txt
+    #   rich
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+pyjwt[crypto]==2.5.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   drf-jwt
+    #   edx-drf-extensions
+pylint==2.13.9
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint-django
     #   pylint-plugin-utils
-pylint-django==2.5.5
+pylint-django==2.5.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.7
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint-django
-pyproject-api==1.8.0
+pymongo==3.12.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-opaque-keys
+pynacl==1.5.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+pyparsing==3.1.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   tox
-pytest==8.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   pytest-django
-pytest-django==4.9.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-python-dotenv==1.0.1
-    # via pydantic-settings
-pyyaml==6.0.2
-    # via
-    #   -r requirements/quality.txt
-    #   pre-commit
-questionary==2.0.1
-    # via bump-my-version
-referencing==0.35.1
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   jsonschema
-    #   jsonschema-specifications
-    #   types-jsonschema
-rich==13.9.4
-    # via
-    #   bump-my-version
-    #   rich-click
-rich-click==1.8.4
-    # via bump-my-version
-rpds-py==0.20.1
+    #   packaging
+pyrsistent==0.20.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   jsonschema
     #   referencing
+pytest==7.1.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pytest-django
+pytest-django==4.5.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+python-dateutil==2.8.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+pytz==2022.2.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   django
+pyyaml==6.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   pre-commit
+referencing==0.8.11
+    # via
+    #   -r requirements/quality.txt
+    #   types-jsonschema
+requests==2.28.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+    #   pyjwkest
+rich==13.9.4
+    # via
+    #   bump-my-version
+    #   rich-click
+rich-click==1.8.6
+    # via bump-my-version
+semantic-version==2.10.0
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+six==1.16.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+    #   pyjwkest
+    #   python-dateutil
+    #   tox
 snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pydocstyle
-sqlparse==0.5.2
+sqlparse==0.4.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-tomli==2.1.0
+stevedore==4.0.0
     # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   django-stubs
-    #   mypy
-    #   pylint
-    #   pyproject-api
-    #   pytest
-    #   tox
-tomlkit==0.13.2
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   bump-my-version
-    #   pylint
-tox==4.23.2
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-types-jsonschema==4.23.0.20240813
-    # via -r requirements/quality.txt
-types-pyyaml==6.0.12.20240917
-    # via
-    #   -r requirements/quality.txt
-    #   django-stubs
-typing-extensions==4.12.2
-    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   annotated-types
-    #   asgiref
+    #   edx-django-utils
+    #   edx-opaque-keys
+tomli==2.0.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   django-stubs
+    #   mypy
+    #   pylint
+    #   pytest
+    #   tox
+tomlkit==0.13.2
+    # via bump-my-version
+tox==3.26.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+types-cryptography==3.3.23
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pyjwt
+types-jsonschema==4.23.0.20241208
+    # via -r requirements/quality.txt
+types-pytz==2024.2.0.20241221
+    # via
+    #   -r requirements/quality.txt
+    #   django-stubs
+types-pyyaml==6.0.12.20241230
+    # via
+    #   -r requirements/quality.txt
+    #   django-stubs
+typing-extensions==4.4.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   astroid
     #   django-stubs
     #   django-stubs-ext
+    #   multidict
     #   mypy
     #   pydantic
-    #   pydantic-core
     #   pylint
     #   rich
     #   rich-click
-    #   tox
-virtualenv==20.27.1
+urllib3==1.26.12
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   requests
+virtualenv==20.16.5
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pre-commit
     #   tox
-wcmatch==10.0
-    # via bump-my-version
-wcwidth==0.2.13
-    # via prompt-toolkit
-zipp==3.20.2
+wrapt==1.14.1
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   astroid
+yarl==1.8.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
+    #   referencing
+zipp==3.9.0
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,34 +4,36 @@
 #
 #    pip-compile --output-file=requirements/pip-tools.txt requirements/pip-tools.in
 #
-
-build==1.2.2.post1
-    # via pip-tools
-click==8.1.7
-    # via pip-tools
-importlib-metadata==8.5.0
+build==0.8.0
+    # via
+    #   -c requirements/constraints.txt
+    #   pip-tools
+click==8.1.3
+    # via
+    #   -c requirements/constraints.txt
+    #   pip-tools
+packaging==21.3
+    # via
+    #   -c requirements/constraints.txt
+    #   build
+pep517==0.13.1
     # via build
-packaging==24.2
-    # via build
-pip-tools==7.4.1
+pip-tools==6.9.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/pip-tools.in
-pyproject-hooks==1.2.0
+pyparsing==3.1.4
+    # via packaging
+tomli==2.0.1
     # via
+    #   -c requirements/constraints.txt
     #   build
-    #   pip-tools
-tomli==2.1.0
-    # via
-    #   build
-    #   pip-tools
-wheel==0.45.0
+    #   pep517
+wheel==0.37.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/pip-tools.in
     #   pip-tools
-zipp==3.20.2
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,218 +4,447 @@
 #
 #    pip-compile --output-file=requirements/quality.txt requirements/quality.in
 #
-
-asgiref==3.8.1
+asgiref==3.5.2
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django
-    #   django-stubs
-astroid==3.2.4 ; python_version < "3.9"
+astroid==2.11.7 ; python_version < "3.9"
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pylint
-attrs==24.2.0
+attrs==22.1.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   jsonschema
+    #   pytest
     #   referencing
-backports-zoneinfo==0.2.1 ; python_version < "3.9"
+certifi==2022.9.24
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-    #   django
-cachetools==5.5.0
+    #   requests
+cffi==1.15.1
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
     #   -r requirements/test.txt
-    #   tox
+    #   cryptography
+    #   pynacl
 cfgv==3.4.0
     # via pre-commit
-chardet==5.2.0
-    # via
-    #   -r requirements/test.txt
-    #   tox
-colorama==0.4.6
-    # via
-    #   -r requirements/test.txt
-    #   tox
-coverage==7.6.1
-    # via -r requirements/test.txt
-dill==0.3.9
-    # via
-    #   -r requirements/test.txt
-    #   pylint
-distlib==0.3.9
-    # via
-    #   -r requirements/test.txt
-    #   virtualenv
-django==4.2.16
+charset-normalizer==2.0.12
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.txt
+    #   requests
+click==8.1.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+coverage==6.5.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+cryptography==36.0.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   pyjwt
+dill==0.3.5.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+    #   pylint
+distlib==0.3.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+    #   virtualenv
+django==3.2.17
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   django-crum
+    #   django-filter
+    #   django-model-utils
     #   django-stubs
     #   django-stubs-ext
-django-stubs[compatible-mypy]==5.1.1
-    # via -r requirements/quality.in
-django-stubs-ext==5.1.1
-    # via django-stubs
-exceptiongroup==1.2.2
+    #   djangorestframework
+    #   drf-jwt
+    #   edx-django-utils
+    #   edx-drf-extensions
+django-crum==0.7.9
     # via
+    #   -r requirements/base.txt
     #   -r requirements/test.txt
-    #   pytest
-filelock==3.16.1
+    #   edx-django-utils
+django-filter==22.1
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+django-model-utils==4.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+django-stubs[compatible-mypy]==1.13.2
+    # via -r requirements/quality.in
+django-stubs-ext==5.1.3
+    # via django-stubs
+django-waffle==3.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+    #   edx-drf-extensions
+djangorestframework==3.12.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   drf-jwt
+    #   edx-drf-extensions
+drf-jwt==1.19.2
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+edx-django-utils==5.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+edx-drf-extensions==8.3.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+edx-opaque-keys==2.3.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+filelock==3.8.0
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
+future==0.18.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   pyjwkest
 identify==2.6.1
     # via pre-commit
-importlib-resources==6.4.5
+idna==3.4
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   requests
+    #   yarl
+importlib-resources==5.10.0
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   jsonschema
-    #   jsonschema-specifications
-iniconfig==2.0.0
+iniconfig==1.1.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pytest
-isort==5.13.2
+isort==5.10.1
     # via
-    #   -r requirements/test.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.in
+    #   -r requirements/test.txt
     #   pylint
-jsonschema==4.23.0
-    # via -r requirements/test.txt
-jsonschema-specifications==2023.12.1
+jsonschema==4.16.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+lazy-object-proxy==1.10.0
     # via
     #   -r requirements/test.txt
-    #   jsonschema
+    #   astroid
 mccabe==0.7.0
     # via
     #   -r requirements/test.txt
     #   pylint
-mypy==1.13.0
+multidict==6.1.0
+    # via yarl
+mypy==0.982
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.in
     #   django-stubs
-mypy-extensions==1.0.0
-    # via mypy
-nodeenv==1.9.1
-    # via pre-commit
-packaging==24.2
+mypy-extensions==0.4.3
     # via
+    #   -c requirements/constraints.txt
+    #   mypy
+newrelic==8.2.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
     #   -r requirements/test.txt
-    #   pyproject-api
+    #   edx-django-utils
+nodeenv==1.7.0
+    # via
+    #   -c requirements/constraints.txt
+    #   pre-commit
+packaging==21.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
     #   pytest
     #   tox
+pbr==5.10.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   stevedore
 pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==4.3.6
+platformdirs==2.5.2
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pylint
-    #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.0.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pytest
     #   tox
 pre-commit==3.5.0
     # via -r requirements/quality.in
-pycodestyle==2.12.1
-    # via -r requirements/test.txt
+psutil==5.9.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+py==1.11.0
+    # via
+    #   -r requirements/test.txt
+    #   pytest
+    #   tox
+pycodestyle==2.8.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+pycparser==2.21
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   cffi
+pycryptodomex==3.15.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   pyjwkest
 pydocstyle==6.3.0
     # via
-    #   -r requirements/test.txt
     #   -r requirements/quality.in
-pylint==3.2.7
+    #   -r requirements/test.txt
+pyjwkest==1.4.2
     # via
+    #   -r requirements/base.txt
     #   -r requirements/test.txt
+    #   edx-drf-extensions
+pyjwt[crypto]==2.5.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   drf-jwt
+    #   edx-drf-extensions
+pylint==2.13.9
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.in
+    #   -r requirements/test.txt
     #   pylint-django
     #   pylint-plugin-utils
-pylint-django==2.5.5
+pylint-django==2.5.3
     # via
-    #   -r requirements/test.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.in
-pylint-plugin-utils==0.8.2
+    #   -r requirements/test.txt
+pylint-plugin-utils==0.7
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pylint-django
-pyproject-api==1.8.0
+pymongo==3.12.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-opaque-keys
+pynacl==1.5.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+pyparsing==3.1.4
     # via
     #   -r requirements/test.txt
-    #   tox
-pytest==8.3.3
-    # via
-    #   -r requirements/test.txt
-    #   pytest-django
-pytest-django==4.9.0
-    # via -r requirements/test.txt
-pyyaml==6.0.2
-    # via pre-commit
-referencing==0.35.1
-    # via
-    #   -r requirements/test.txt
-    #   jsonschema
-    #   jsonschema-specifications
-    #   types-jsonschema
-rpds-py==0.20.1
+    #   packaging
+pyrsistent==0.20.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
     #   referencing
+pytest==7.1.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+    #   pytest-django
+pytest-django==4.5.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+python-dateutil==2.8.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+pytz==2022.2.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   django
+pyyaml==6.0
+    # via
+    #   -c requirements/constraints.txt
+    #   pre-commit
+referencing==0.8.11
+    # via types-jsonschema
+requests==2.28.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+    #   pyjwkest
+semantic-version==2.10.0
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+six==1.16.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-drf-extensions
+    #   pyjwkest
+    #   python-dateutil
+    #   tox
 snowballstemmer==2.2.0
     # via
     #   -r requirements/test.txt
     #   pydocstyle
-sqlparse==0.5.2
+sqlparse==0.4.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django
-tomli==2.1.0
+stevedore==4.0.0
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
+    #   edx-opaque-keys
+tomli==2.0.1
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   django-stubs
     #   mypy
     #   pylint
-    #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.13.2
+tox==3.26.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-    #   pylint
-tox==4.23.2
-    # via -r requirements/test.txt
-types-jsonschema==4.23.0.20240813
-    # via -r requirements/quality.in
-types-pyyaml==6.0.12.20240917
-    # via django-stubs
-typing-extensions==4.12.2
+types-cryptography==3.3.23
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-    #   asgiref
+    #   pyjwt
+types-jsonschema==4.23.0.20241208
+    # via -r requirements/quality.in
+types-pytz==2024.2.0.20241221
+    # via django-stubs
+types-pyyaml==6.0.12.20241230
+    # via django-stubs
+typing-extensions==4.4.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
     #   astroid
     #   django-stubs
     #   django-stubs-ext
+    #   multidict
     #   mypy
     #   pylint
-    #   tox
-virtualenv==20.27.1
+urllib3==1.26.12
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
+    #   requests
+virtualenv==20.16.5
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pre-commit
     #   tox
-zipp==3.20.2
+wrapt==1.14.1
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+    #   astroid
+yarl==1.8.1
+    # via
+    #   -c requirements/constraints.txt
+    #   referencing
+zipp==3.9.0
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,128 +4,322 @@
 #
 #    pip-compile --output-file=requirements/test.txt requirements/test.in
 #
-
-asgiref==3.8.1
+asgiref==3.5.2
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django
-astroid==3.2.4 ; python_version < "3.9"
+astroid==2.11.7 ; python_version < "3.9"
     # via
     #   -c requirements/constraints.txt
     #   pylint
-attrs==24.2.0
+attrs==22.1.0
     # via
+    #   -c requirements/constraints.txt
     #   jsonschema
-    #   referencing
-backports-zoneinfo==0.2.1 ; python_version < "3.9"
+    #   pytest
+certifi==2022.9.24
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-    #   django
-cachetools==5.5.0
-    # via tox
-chardet==5.2.0
-    # via tox
-colorama==0.4.6
-    # via tox
-coverage==7.6.1
-    # via -r requirements/test.in
-dill==0.3.9
-    # via pylint
-distlib==0.3.9
-    # via virtualenv
+    #   requests
+cffi==1.15.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-exceptiongroup==1.2.2
-    # via pytest
-filelock==3.16.1
+    #   cryptography
+    #   pynacl
+charset-normalizer==2.0.12
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   requests
+click==8.1.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-django-utils
+coverage==6.5.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+cryptography==36.0.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   pyjwt
+dill==0.3.5.1
+    # via
+    #   -c requirements/constraints.txt
+    #   pylint
+distlib==0.3.6
+    # via
+    #   -c requirements/constraints.txt
+    #   virtualenv
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   django-crum
+    #   django-filter
+    #   django-model-utils
+    #   djangorestframework
+    #   drf-jwt
+    #   edx-django-utils
+    #   edx-drf-extensions
+django-crum==0.7.9
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+django-filter==22.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+django-model-utils==4.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+django-waffle==3.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-drf-extensions
+djangorestframework==3.12.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   drf-jwt
+    #   edx-drf-extensions
+drf-jwt==1.19.2
+    # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+edx-django-utils==5.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+edx-drf-extensions==8.3.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+edx-opaque-keys==2.3.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+filelock==3.8.0
+    # via
+    #   -c requirements/constraints.txt
     #   tox
     #   virtualenv
-importlib-resources==6.4.5
+future==0.18.2
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   pyjwkest
+idna==3.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   requests
+importlib-resources==5.10.0
+    # via
+    #   -c requirements/constraints.txt
     #   jsonschema
-    #   jsonschema-specifications
-iniconfig==2.0.0
-    # via pytest
-isort==5.13.2
+iniconfig==1.1.1
     # via
+    #   -c requirements/constraints.txt
+    #   pytest
+isort==5.10.1
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
     #   pylint
-jsonschema==4.23.0
-    # via -r requirements/test.in
-jsonschema-specifications==2023.12.1
-    # via jsonschema
+jsonschema==4.16.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+lazy-object-proxy==1.10.0
+    # via astroid
 mccabe==0.7.0
     # via pylint
-packaging==24.2
+newrelic==8.2.1
     # via
-    #   pyproject-api
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-django-utils
+packaging==21.3
+    # via
+    #   -c requirements/constraints.txt
     #   pytest
     #   tox
+pbr==5.10.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   stevedore
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.3.6
+platformdirs==2.5.2
     # via
+    #   -c requirements/constraints.txt
     #   pylint
-    #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   pytest
+    #   tox
+psutil==5.9.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-django-utils
+py==1.11.0
     # via
     #   pytest
     #   tox
-pycodestyle==2.12.1
-    # via -r requirements/test.in
+pycodestyle==2.8.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+pycparser==2.21
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   cffi
+pycryptodomex==3.15.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   pyjwkest
 pydocstyle==6.3.0
     # via -r requirements/test.in
-pylint==3.2.7
+pyjwkest==1.4.2
     # via
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+pyjwt[crypto]==2.5.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   drf-jwt
+    #   edx-drf-extensions
+pylint==2.13.9
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
     #   pylint-django
     #   pylint-plugin-utils
-pylint-django==2.5.5
-    # via -r requirements/test.in
-pylint-plugin-utils==0.8.2
-    # via pylint-django
-pyproject-api==1.8.0
-    # via tox
-pytest==8.3.3
-    # via pytest-django
-pytest-django==4.9.0
-    # via -r requirements/test.in
-referencing==0.35.1
+pylint-django==2.5.3
     # via
-    #   jsonschema
-    #   jsonschema-specifications
-rpds-py==0.20.1
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+pylint-plugin-utils==0.7
     # via
-    #   jsonschema
-    #   referencing
-snowballstemmer==2.2.0
-    # via pydocstyle
-sqlparse==0.5.2
+    #   -c requirements/constraints.txt
+    #   pylint-django
+pymongo==3.12.3
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-opaque-keys
+pynacl==1.5.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-django-utils
+pyparsing==3.1.4
+    # via packaging
+pyrsistent==0.20.0
+    # via jsonschema
+pytest==7.1.3
+    # via
+    #   -c requirements/constraints.txt
+    #   pytest-django
+pytest-django==4.5.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+python-dateutil==2.8.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+pytz==2022.2.1
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django
-tomli==2.1.0
+requests==2.28.1
     # via
-    #   pylint
-    #   pyproject-api
-    #   pytest
-    #   tox
-tomlkit==0.13.2
-    # via pylint
-tox==4.23.2
-    # via -r requirements/test.in
-typing-extensions==4.12.2
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+    #   pyjwkest
+semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
-    #   asgiref
+    #   edx-drf-extensions
+six==1.16.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-drf-extensions
+    #   pyjwkest
+    #   python-dateutil
+    #   tox
+snowballstemmer==2.2.0
+    # via pydocstyle
+sqlparse==0.4.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   django
+stevedore==4.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-opaque-keys
+tomli==2.0.1
+    # via
+    #   -c requirements/constraints.txt
+    #   pylint
+    #   pytest
+    #   tox
+tox==3.26.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+types-cryptography==3.3.23
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   pyjwt
+typing-extensions==4.4.0
+    # via
+    #   -c requirements/constraints.txt
     #   astroid
     #   pylint
+urllib3==1.26.12
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+    #   requests
+virtualenv==20.16.5
+    # via
+    #   -c requirements/constraints.txt
     #   tox
-virtualenv==20.27.1
-    # via tox
-zipp==3.20.2
-    # via importlib-resources
+wrapt==1.14.1
+    # via
+    #   -c requirements/constraints.txt
+    #   astroid
+zipp==3.9.0
+    # via
+    #   -c requirements/constraints.txt
+    #   importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
## Description

This PR adds some relevant dependencies that were missed from the build structure of the project. 

## Changes made

- [x] add Django rest framework and its edx-extensions
- [x] adds model utils for TimeStampedModel usages
- [x] adds missed edx-opaque-keys and django-filter dependency  

## How to test:

- Checkout to egs/missed-dependencies
- Using a python 3.8 enviroment execute `make requirements`
- If desire, execute `make quality` confirms that there are not missing imports to process. 