### PR TITLE
fix: add support to obtain subclasses from Flexible Catalogue API.

### DIFF
--- a/catalog_plugin/api/catalog_api_client.py
+++ b/catalog_plugin/api/catalog_api_client.py
@@ -77,11 +77,11 @@ class FlexibleCatalogAPIClient:
                 lookup_query = Q()
                 for key, value in self.lookup_dict.items():
                     lookup_query &= Q(**{key: value})
-                return FlexibleCatalogModel.objects.filter(lookup_query)
+                return FlexibleCatalogModel.objects.filter(lookup_query).select_subclasses()
             elif self.catalog_uuid:
-                return FlexibleCatalogModel.objects.get(id=self.catalog_uuid)
+                return FlexibleCatalogModel.objects.get_subclass(id=self.catalog_uuid)
             elif self.catalog_slug:
-                return FlexibleCatalogModel.objects.get(slug=self.catalog_slug)
+                return FlexibleCatalogModel.objects.get_subclass(slug=self.catalog_slug)
         except FlexibleCatalogModel.DoesNotExist:
             logger.warning(
                 'FlexibleCatalogModel not found. UUID: %s, Slug: %s, Lookup Dict: %s',


### PR DESCRIPTION
## Description:

This PR fixes the FlexibleCatalogueAPIClient.fetch_flexible_catalog method to obtain the actual subclass of FlexibleCatalogModel instead of a FlexibleCatalogModel instance. To obtain the benefits of the InheritanceManager, these queries need to call the subclasses methods. https://django-model-utils.readthedocs.io/en/latest/managers.html#inheritancemanager

## How to test:

- Create some AvailableCourses entries.
- Create a CatalogCourses entry.
- Open a shell in the LMS and import FlexibleCatalogAPIClient.
- Instantiate a FlexibleCatalogAPIClient object.
- Call get_flexible_catalog and check the type of the returned object. Without this change it will return a FlexibleCatalogModel instance, with this change, it will return a CatalogCourses instance.

## Screenshot:

![image](https://github.com/user-attachments/assets/928c6fd5-8568-4b67-b461-95b28dd7d15a)

## Reviewers:

- [x] @anfbermudezme 