### PR TITLE
PADV-2873: Improve AvailableCourse lookup by course__id

### DIFF
--- a/catalog_plugin/admin.py
+++ b/catalog_plugin/admin.py
@@ -131,4 +131,4 @@ class AvailableCourseAdmin(admin.ModelAdmin):
     """Admin for the AvailableCourse model."""
 
     list_display = ('id', 'course', 'active')
-    search_fields = ('course',)
+    search_fields = ('course__id',)


### PR DESCRIPTION
## Tickets

https://pearson.atlassian.net/browse/PADV-2873

## Description

This PR improve AvailableCourse lookup by course__id. It was raising an error when it tried to lookup by any value.

## How To Test

- Start openedx services.
- Install catalog plugin in this branch.
- Open AvailableCourse table in Django Admin (http://localhost:18000/admin/catalog_plugin/availablecourse).
- Lookup any record.
- Check if the given result is correct.