### PR TITLE
PADV-3296: Exclude CCX courses from AvailableCourse admin dropdown

### DIFF
--- a/catalog_plugin/admin.py
+++ b/catalog_plugin/admin.py
@@ -128,3 +128,9 @@ class AvailableCourseAdmin(admin.ModelAdmin):
 
     list_display = ('id', 'course', 'active')
     search_fields = ('course__id',)
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        """Exclude CCX courses from the `course` dropdown so only master courses are selectable."""
+        if db_field.name == 'course':
+            kwargs['queryset'] = db_field.related_model.objects.exclude(id__startswith='ccx-v1:')
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/catalog_plugin/admin.py
+++ b/catalog_plugin/admin.py
@@ -139,4 +139,7 @@ class AvailableCourseAdmin(admin.ModelAdmin):
                 .exclude(id__startswith='ccx-v1:')
                 .filter(Q(end__isnull=True) | Q(end__gte=timezone.now()))
             )
+            kwargs['help_text'] = (
+                'CCX courses and courses with an end date in the past are hidden from this list.'
+            )
         return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/catalog_plugin/admin.py
+++ b/catalog_plugin/admin.py
@@ -1,6 +1,8 @@
 """Django admin pages for Catalog models."""
 from django.contrib import admin
+from django.db.models import Q
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.html import format_html
 
 from catalog_plugin.models import AvailableCourse, CatalogCourses, DynamicCatalog, FixedCatalog, FlexibleCatalogModel
@@ -130,7 +132,11 @@ class AvailableCourseAdmin(admin.ModelAdmin):
     search_fields = ('course__id',)
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
-        """Exclude CCX courses from the `course` dropdown so only master courses are selectable."""
+        """Exclude CCX courses and ended courses from the `course` dropdown."""
         if db_field.name == 'course':
-            kwargs['queryset'] = db_field.related_model.objects.exclude(id__startswith='ccx-v1:')
+            kwargs['queryset'] = (
+                db_field.related_model.objects
+                .exclude(id__startswith='ccx-v1:')
+                .filter(Q(end__isnull=True) | Q(end__gte=timezone.now()))
+            )
         return super().formfield_for_foreignkey(db_field, request, **kwargs)


### PR DESCRIPTION
## Tickets

https://pearson.atlassian.net/browse/PADV-3296

## Description

The Django admin form for AvailableCourse currently lists every CourseOverview in the dropdown of the course foreign key including CCX courses (keys with prefix ccx-v1:...). We want the dropdown to show only master courses (course-v1:...).

### Note: `formfield_for_foreignkey`

`formfield_for_foreignkey` is a hook provided by Django's `ModelAdmin` that runs whenever the admin builds a form field for a `ForeignKey`. It receives the FK definition (`db_field`), the request, and the kwargs that Django will pass to the underlying `ModelChoiceField` constructor, most notably `kwargs['queryset']`, which controls **which rows populate the dropdown**.

Overriding it lets us replace the default queryset (`CourseOverview.objects.all()`) with a filtered one (`.exclude(id__startswith='ccx-v1:')`) **only for the `course` FK** (we guard with `if db_field.name == 'course'` so other FKs added in the future are unaffected). After mutating `kwargs`, we delegate to `super()` so Django builds the field normally with our filtered queryset.

This is the recommended extension point for this use case: `get_queryset` only affects the changelist, `limit_choices_to` would couple admin-UI concerns to the model layer, and `autocomplete_fields`/`raw_id_fields` change the widget but not the queryset.

### Also exclude ended courses from the dropdown

Extend the `course` FK queryset filter so the dropdown additionally hides any `CourseOverview` whose `end` date is in the past. Courses with `end IS NULL` (self-paced or no scheduled end) and courses ending today or in the future remain selectable.

The condition is expressed as `Q(end__isnull=True) | Q(end__gte=timezone.now())` to be NULL-safe: a plain `.exclude(end__lt=now)` would incorrectly drop rows with `end IS NULL` due to SQL three-valued logic (`NULL < now` evaluates to `NULL`, and `NOT NULL` is also `NULL`, not `TRUE`).

`timezone.now()` is used (not `datetime.now()`) so the comparison is timezone-aware and consistent with how Django stores `DateTimeField` values when `USE_TZ=True`.

<img width="655" height="279" alt="image" src="https://github.com/user-attachments/assets/e9eea264-95ca-4fe7-8abe-0e8deffa0e39" />



## How To Test

- Go to /admin/catalog_plugin/availablecourse/add/, open the course dropdown, and verify no ccx-v1:... entries appear.
- Select a master course, save, and confirm the new AvailableCourse was created.
- Open an existing AvailableCourse that points to a master course; confirm the form loads correctly and the dropdown excludes CCX.
- (Regression) Confirm the changelist /admin/catalog_plugin/availablecourse/ still renders and search by course__id still works.
- Check if the dropdown is filtering out master courses with end date (CourseOverview.end) in the past