### PR TITLE
PADV-3538.fix: Add CMS entry points to prevent initialization errors for pearson_course_operation.

### DIFF
--- a/catalog_plugin/apps.py
+++ b/catalog_plugin/apps.py
@@ -24,5 +24,9 @@ class CatalogPluginConfig(AppConfig):
                 'common': {'relative_path': 'settings.common'},
                 'test': {'relative_path': 'settings.test'},
             },
+            'cms.djangoapp': {
+                'common': {'relative_path': 'settings.common'},
+                'test': {'relative_path': 'settings.test'},
+            },
         },
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ version = { attr = 'catalog_plugin.__version__' }
 
 [project.entry-points.'lms.djangoapp']
 catalog = 'catalog_plugin.apps:CatalogPluginConfig'
-
+[project.entry-points.'cms.djangoapp']
+catalog = 'catalog_plugin.apps:CatalogPluginConfig'
 
 # -----------
 # Versioning.


### PR DESCRIPTION
### Description

The lack of definition of the catalog plugin's CMS entry point was causing dependency conflicts when initializing `pearson_course_operation` within the CMS. We need to include this project as a `cms.djangoapp` to fix that problem.

### Why do we need Course Operations In the CMS? 

If you need to understand more about this, please refer to `https://github.com/Pearson-Advance/course_operations/blob/pearson/ulmo/pearson_course_operation/docs/decisions/009-sql-cache-pattern-modulestore.rst` . 

### Ticket

- https://github.com/Pearson-Advance/course_operations/pull/472